### PR TITLE
Adds nconf to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nib/nconf-transforms",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "web.config like transforms for nconf",
   "repository": "https://github.com/nib-health-funds/nconf-transforms",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "repository": "https://github.com/nib-health-funds/nconf-transforms",
   "dependencies": {
     "chokidar": "^1.2.0",
-    "nconf": "^0.8.2",
     "glob": "^5.0.15"
+  },
+  "peerDependencies": {
+    "nconf": "^0.8.2"
   },
   "main": "index.js"
 }


### PR DESCRIPTION
Consumers of this library are dependant on having nconf available. Add nconf to peer dependencies to enforce this relationship